### PR TITLE
Correct mapper preferences errors (alpha 2)

### DIFF
--- a/bin/gmaprofile.tcl
+++ b/bin/gmaprofile.tcl
@@ -78,7 +78,7 @@ namespace eval ::gmaprofile {
 		return [dict create \
 			animate         false\
 			button_size     small\
-			curl_path       /usr/bin/curl\
+			curl_path       [::gmautil::searchInPath curl]\
 			current_profile offline\
 			dark            false\
 			debug_level     0\
@@ -110,19 +110,19 @@ namespace eval ::gmaprofile {
 			update_url {} \
 			module_id {} \
 			server_mkdir {} \
-			nc_path {} \
-			scp_path {} \
+			nc_path [::gmautil::searchInPath nc] \
+			scp_path [::gmautil::searchInPath scp] \
 			scp_dest {} \
 			scp_server {} \
 			scp_proxy {} \
-			ssh_path {} \
+			ssh_path [::gmautil::searchInPath ssh] \
 		]
 	}
 	proc _add_new {w} {
 		variable _profile
-		if {[::getstring::tk_getString .new_profile_name newname {Name of new server profile}] && $newname ne {}} {
+		if {[::getstring::tk_getString $w.new_profile_name newname {Name of new server profile}] && $newname ne {}} {
 			if {[find_server_index $_profile $newname] >= 0} {
-				tk_messageBox -type ok -icon error -title "Duplicate name" -message "You tried to add a server called \"$newname\" but that name already exists in the profile set."
+				tk_messageBox -type ok -icon error -title "Duplicate name" -message "You tried to add a server called \"$newname\" but that name already exists in the profile set." -parent $w
 				return
 			}
 			$w.n.p.servers insert end $newname
@@ -137,14 +137,14 @@ namespace eval ::gmaprofile {
 		variable _profile
 		_save_server $w
 		if {$currently_editing_index < 0} {
-			tk_messageBox -type ok -icon error -title "No current selection" -message "You can't make a copy of a profile without first selecting the profile to copy from."
+			tk_messageBox -type ok -icon error -title "No current selection" -message "You can't make a copy of a profile without first selecting the profile to copy from." -parent $w
 			return
 		}
 		set serverdata [lindex [dict get $_profile profiles] $currently_editing_index]
 		set servername [dict get $serverdata name]
-		if {[::getstring::tk_getString .new_profile_name newname "Name of new server profile (copy of $servername)"] && $newname ne {}} {
+		if {[::getstring::tk_getString $w.new_profile_name newname "Name of new server profile (copy of $servername)"] && $newname ne {}} {
 			if {[find_server_index $_profile $newname] >= 0} {
-				tk_messageBox -type ok -icon error -title "Duplicate name" -message "You tried to add a server called \"$newname\" but that name already exists in the profile set."
+				tk_messageBox -type ok -icon error -title "Duplicate name" -message "You tried to add a server called \"$newname\" but that name already exists in the profile set." -parent $w
 				return
 			}
 			$w.n.p.servers insert end $newname
@@ -159,12 +159,12 @@ namespace eval ::gmaprofile {
 		variable currently_editing_index
 		variable _profile
 		if {$currently_editing_index < 0} {
-			tk_messageBox -type ok -icon error -title "No current selection" -message "You can't delete a profile without first selecting it."
+			tk_messageBox -type ok -icon error -title "No current selection" -message "You can't delete a profile without first selecting it." -parent $w
 			return
 		}
 		set serverdata [lindex [dict get $_profile profiles] $currently_editing_index]
 		set servername [dict get $serverdata name]
-		if {! [tk_messageBox -type yesno -default no -icon warning -title "Confirm Deletion" -message "Are you SURE you want to delete the server profile \"$servername\"? This operation cannot be undone."]} {
+		if {! [tk_messageBox -type yesno -default no -icon warning -title "Confirm Deletion" -message "Are you SURE you want to delete the server profile \"$servername\"? This operation cannot be undone." -parent $w]} {
 			return
 		}
 		dict set _profile profiles [lreplace [dict get $_profile profiles] $currently_editing_index $currently_editing_index]
@@ -350,7 +350,7 @@ namespace eval ::gmaprofile {
 			set servername [$w.n.p.servers get [lindex $serveridx 0]]
 			dict set _profile current_profile $servername
 			if {[set si [find_server_index $_profile $servername]] < 0} {
-				tk_messageBox -type ok -icon error -title "No such server" -message "You tried to select a server called \"$servername\" but no such entry exists in the profile set."
+				tk_messageBox -type ok -icon error -title "No such server" -message "You tried to select a server called \"$servername\" but no such entry exists in the profile set." -parent $w
 				_select_server $w {}
 				return
 			}

--- a/bin/gmaproto.tcl
+++ b/bin/gmaproto.tcl
@@ -231,14 +231,17 @@ proc ::gmaproto::dial {host port user pass proxy proxyport proxyuser proxypass c
 }
 
 proc ::gmaproto::hangup {} {
+	::gmaproto::DEBUG "hangup"
 	set ::gmaproto::host {}
 	::gmaproto::redial
 }
 
-# we can all redial anytime we find we want to send something and we have no socket
+# we can call redial anytime we find we want to send something and we have no socket
 proc ::gmaproto::redial {} {
+	::gmaproto::DEBUG "redial"
 	set ::gmaproto::recv_buffer {}
 	if {$::gmaproto::host eq {}} {
+		::gmaproto::DEBUG "hanging up ($::gmaproto::sock)"
 		catch {close $::gmaproto::sock}
 		set ::gmaproto::sock {}
 		set ::gmaproto::pending_login true

--- a/bin/gmautil.tcl
+++ b/bin/gmautil.tcl
@@ -528,3 +528,13 @@ proc ::gmautil::dassign {dictval args} {
     }
 }
 
+# Search for a command in the user's PATH
+proc ::gmautil::searchInPath {cmd} {
+	global env
+	foreach dir [split $env(PATH) :] {
+		if {[file executable [file join $dir $cmd]]} {
+			return [file join $dir $cmd]
+		}
+	}
+	return ""
+}

--- a/bin/gmautil.tcl
+++ b/bin/gmautil.tcl
@@ -531,9 +531,11 @@ proc ::gmautil::dassign {dictval args} {
 # Search for a command in the user's PATH
 proc ::gmautil::searchInPath {cmd} {
 	global env
-	foreach dir [split $env(PATH) :] {
-		if {[file executable [file join $dir $cmd]]} {
-			return [file join $dir $cmd]
+	if {[info exists env(PATH)]} {
+		foreach dir [split $env(PATH) :] {
+			if {[file executable [file join $dir $cmd]]} {
+				return [file join $dir $cmd]
+			}
 		}
 	}
 	return ""

--- a/bin/mapper.tcl
+++ b/bin/mapper.tcl
@@ -14,7 +14,7 @@
 # GMA Mapper Client with background I/O processing.
 #
 # Auto-configure values
-set GMAMapperVersion {4.4.0-alpha.1}     ;# @@##@@
+set GMAMapperVersion {4.4.0-alpha.2}     ;# @@##@@
 set GMAMapperFileFormat {20}        ;# @@##@@
 set GMAMapperProtocol {402}         ;# @@##@@
 set GMAVersionNumber {5.2}            ;# @@##@@
@@ -10911,11 +10911,8 @@ proc ConnectToServerByIdx {idx} {
 	#::gmaprofile::save $preferences_path $newdata
 	ApplyPreferences $newdata
 	global IThost
-	DEBUG 0 "set server $idx; prefs not $newdata; host is $IThost"
 	::gmaproto::hangup
-	DEBUG 0 "waiting for connect"
 	WaitForConnectToServer
-	DEBUG 0 "done"
 	refresh_title
 }
 


### PR DESCRIPTION
This corrects errors in the --select and "connect to" options. There are still some odd behaviors caused by changing the connection after the app is already started (like the chat history won't be reloaded correctly and some server-specific buttons may not work quite right), but that will take a more substantial rewrite than just putting this feature in place.