### PR TITLE
removed extra call to animation_init

### DIFF
--- a/bin/mapper.tcl
+++ b/bin/mapper.tcl
@@ -2644,7 +2644,7 @@ proc loadfile {file args} {
 										      {Animation FrameSpeed} aspeed \
 										      {Animation Loops} aloops
 								fetch_animated_image $image_id $image_zoom $image_filename $aframes $aspeed $aloops
-								animation_init [tile_id $image_id $image_zoom] $aframes $aspeed $aloops
+								#animation_init [tile_id $image_id $image_zoom] $aframes $aspeed $aloops
 							} else {
 								fetch_image $image_id $image_zoom $image_filename
 								set TILE_ID([tile_id $image_id $image_zoom]) $image_filename


### PR DESCRIPTION
Fixes a bug where images loaded from a map file are cleared in-memory to a null stack of frames.