### PR TITLE
--list-profiles option

### DIFF
--- a/bin/mapper.tcl
+++ b/bin/mapper.tcl
@@ -1427,6 +1427,7 @@ proc usage {} {
 	puts $stderr {       --help:        Print this information and exit}
 	puts $stderr {   -h, --host:        Hostname for initiative tracker [none]}
 	puts $stderr {   -k, --keep-tools:  Don't allow remote disabling of the toolbar}
+	puts $stderr {   -L, --list-profiles: Print available profiles you can use with --select}
 	puts $stderr {   -l, --preload:     Load all cached images at startup}
 	puts $stderr {   -M, --module:      Set module ID (SaF GM role only)}
 	puts $stderr {   -n, --no-chat:		Do not display incoming chat messages}
@@ -1565,6 +1566,19 @@ for {set argi 0} {$argi < $optc} {incr argi} {
 		-S - --select     { 
 			set CurrentProfileName [getarg -S]
 			ApplyPreferences $PreferencesData -override
+		}
+		-L - --list-profiles { 
+			puts "The following server profiles are defined in your preferences data."
+			puts "You may use one of these as the argument to the --select option (-S):"
+			foreach server [dict get $PreferencesData profiles] {
+				puts [format "  profile: %-20s: user: %-10s host: %s:%s" \
+					[dict get $server name] \
+					[dict get $server username] \
+					[dict get $server host] \
+					[dict get $server port] \
+				]
+			}
+			exit 0
 		}
 		-s - --style      { puts "The --style option is deprecated." }
 		-t - --transcript { set ChatTranscript [getarg -t] }
@@ -13281,7 +13295,7 @@ proc ConnectToServerByIdx {idx} {
 		return
 	}
 	set profilename [dict get $newdata current_profile]
-	tk_messageBox -type ok -icon warning -title "Not Recommended" -message "We will attempt to reconnect you now to your \"$profilename\" server profile; however, this is not guaranteed to work 100% due to some known issues with the implementation of this feature.\n\nInstead, we recommend either of these methods which will work perfectly:\n(1) On the command line, add a --select '$profilename' switch to the mapper command;\n(2) Select Edit -> Preferences from the menu, click the Servers tab, click on $profilename, save, and click Yes to have the mapper restart with those settings."
+	tk_messageBox -type ok -icon warning -title "Not Recommended" -message "We will attempt to reconnect you now to your \"$profilename\" server profile; however, this is not guaranteed to work 100% due to some known issues with the implementation of this feature.\n\nInstead, we recommend either of these methods which will work perfectly:\n(1) On the command line, add a --select '$profilename' switch to the mapper command;\n(2) Select Edit -> Preferences from the menu, click the Servers tab, click on $profilename, save, and click Yes to have the mapper restart with those settings.\nTo see a list of available profiles, run the mapper with the --list-profiles option."
 	set PreferencesData $newdata
 	#::gmaprofile::save $preferences_path $newdata
 	ApplyPreferences $newdata

--- a/man/man6/mapper.6
+++ b/man/man6/mapper.6
@@ -41,6 +41,7 @@ mapper \- GMA battle grid map
 .RB [ \-h
 .IR hostname ]
 .RB [ \-k ]
+.RB [ \-L ]
 .RB [ \-l ]
 .RB [ \-M
 .IR module ]
@@ -122,6 +123,7 @@ mapper \- GMA battle grid map
 .RB [ \-\-image\-format
 .IR fmt ]
 .RB [ \-\-keep\-tools ]
+.RB [ \-\-list\-profiles ]
 .RB [ \-\-major
 .IR n [\fB+\fP x [\fB:\fP y ]]]
 .RB [ \-\-mkdir\-path
@@ -575,6 +577,17 @@ his console as needed.  If this option is given, this causes the client to uncon
 display its toolbar anyway. This is used for the main map run by the GM or whomever else is
 managing the group map and needs the toolbar active, or if people just want to keep the toolbar all
 the time.
+'\" <<New>>
+.TP
+.BR \-L ", " \-\-list\-profiles
+List all the available profiles in the current preferences settings (either the default set for
+the mapper client or the one specified with the
+.B \-\-preferences
+option). This list is printed to the standard output and then the mapper exits.
+These are the profile names which may be given to the
+.B \-\-select
+option.
+'\" <</New>>
 .TP
 .BI "\-G\fR, \fP\-\-major " n
 Make every


### PR DESCRIPTION
Adds a `--list-profiles` (`-L`) option to list the defined profile names that can be used with the `--select` option.